### PR TITLE
Invert actual and expected

### DIFF
--- a/kotlintest/src/test/kotlin/me/rozkmin/testing/kotlintest/UseCaseTest.kt
+++ b/kotlintest/src/test/kotlin/me/rozkmin/testing/kotlintest/UseCaseTest.kt
@@ -12,7 +12,7 @@ class UseCaseTest : WordSpec({
             val actual = useCase.execute()
             val expected = ""
 
-            expected shouldBe actual
+            actual shouldBe expected
         }
     }
 })


### PR DESCRIPTION
When using `shouldBe`, the syntax should be something similar to "this should be that", and not "that should be this". With this change, the semantics are fixed